### PR TITLE
出品ページのバリデーションメッセージ表示位置修正

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -7,7 +7,7 @@ $(function(){
     var childSelectHtml = '';
     childSelectHtml =  `<div class='category-select-child'>
                           <select class="category-select-wrapper__box--select" id="child_category" name="item[child_category_id]">
-                            <option value="選択してください">選択してください</option>
+                            <option value="">選択してください</option>
                             ${insertHTML}
                           </select>
                           <svg class='childCategory-svg', aria-hidden="true", fill="888888", fill-rule= "evenodd", height="24", view="0 0 24 24", width="24">
@@ -20,7 +20,7 @@ $(function(){
     var grandchildSelectHtml = '';
     grandchildSelectHtml = `<div class='category-select-grandchild'>
                               <select class="category-select-wrapper__box--select" id="grandchild_category" name="item[category_id]">
-                                <option value="選択してください">選択してください</option>
+                                <option value="">選択してください</option>
                                 ${insertHTML}
                               </select>
                               <svg class='grandChildCategory-svg', aria-hidden="true", fill="888888", fill-rule= "evenodd", height="24", view="0 0 24 24", width="24">
@@ -29,6 +29,7 @@ $(function(){
                             </div>`;
     $('.category-section__pulldown').append(grandchildSelectHtml);
   }
+
 
   $('#parent_category').on('change', function(){
     var parentCategory = $(this).val(); 

--- a/app/assets/javascripts/favorite.js
+++ b/app/assets/javascripts/favorite.js
@@ -37,7 +37,7 @@ $(function() {
         contentType: false
       })
       .done(function(data){ 
-        $('.counts').html(`<p>お気に入り数：${data.counts}</p>`)
+        $('.favorite').html(`<p>お気に入り数：${data.counts}</p>`)
         $('.favorites_buttons').html(`<form class="button_to" method="delete" action="/items/${data.item_id}/favorites/${data.id}"><input type="submit" value="いいねを取り消す" id="delete-good" ></form>`)
       })
     } else {
@@ -51,7 +51,7 @@ $(function() {
       })
       .done(function(data){ 
         var itemId = $('.favorites_buttons').data('id'); //ビューのfavorites_buttonsクラス内にあるdata-indaxを取得
-        $('.counts').html(`<p>お気に入り数：${data.counts}</p>`)
+        $('.favorite').html(`<p>お気に入り数：${data.counts}</p>`)
         $('.favorites_buttons').html(`<form class="button_to" method="post" action="/items/${itemId}/favorites"><input type="submit" value="いいね" id="good" /></form>`)
       })
     }

--- a/app/assets/javascripts/validate_item.js
+++ b/app/assets/javascripts/validate_item.js
@@ -1,7 +1,4 @@
 $(function(){
-
-  const imagesForm = "#item_images_attributes_0_image, #item_images_attributes_1_image, #item_images_attributes_2_image, #item_images_attributes_3_image, #item_images_attributes_4_image"
-
   $('#new_item').validate({
     ignore: [],
     // 画像フォームは複数あるので、フォームの数分エラーメッセージが表示されてしまうので

--- a/app/assets/javascripts/validate_item.js
+++ b/app/assets/javascripts/validate_item.js
@@ -155,12 +155,10 @@ $(function(){
     }
   })
   $('#new_item').on('blur', '#item_name, #item_description, #parent_category, #child_category, #grandchild_category, #item_condition, #item_shipping_attributes_shipping_fee, #item_shipping_attributes_shippingway_id, #item_shipping_attributes_shippingarea_id, #item_shipping_attributes_shipping_day, #item_price', function() { 
-    console.log(1);  
     $(this).valid();
   });
   // 画像フォームはblurイベントだと発火しないのでchangeイベントに設定
   $('#new_item').on('change','#item_images_attributes_0_image, #item_images_attributes_1_image, #item_images_attributes_2_image, #item_images_attributes_3_image, #item_images_attributes_4_image', function() {   
     $(this).valid();
-    console.log(2); 
   });
 })

--- a/app/assets/javascripts/validate_item.js
+++ b/app/assets/javascripts/validate_item.js
@@ -1,0 +1,156 @@
+// $(function(){
+
+//   $('#new_item').validate({
+//     ignore: [],
+//     groups: {
+//       images: "item[images_attributes][0][image] item[images_attributes][1][image] item[images_attributes][2][image] item[images_attributes][3][image] item[images_attributes][4][image]"
+//     },
+//     rules: {
+//       "item[images_attributes][0][image]": {
+//         required: function(element){
+//           if ($("#item_images_attributes_1_image").val()==="" && $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
+//             return true;
+//           }
+//         }
+//       }, 
+//       "item[images_attributes][1][image]": {
+//         required: function(element){
+//           if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
+//             return true;
+//           }
+//         }
+//       }, 
+//       "item[images_attributes][2][image]": {
+//         required: function(element){
+//           if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
+//             return true;
+//           }
+//       }
+//     }, 
+//       "item[images_attributes][3][image]": {
+//         required: function(element){
+//           if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()===""&& $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
+//             return true;
+//           }
+//       }
+//       }, 
+//       "item[images_attributes][4][image]": {
+//         required: function(element){
+//           if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()===""&& $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()===""){
+//             return true;
+//           }
+//         }
+//       }, 
+//       "item[name]": {
+//         required: true,
+//         maxlength: 40
+//       },
+//       "item[description]": {
+//         required: true,
+//         maxlength: 1000
+//       },
+//       "item[parent_category_id]": {
+//         required: true
+//       },
+//       "item[child_category_id]": { 
+//         required: true
+//       },
+//       "item[category_id]": {
+//         required: true
+//       },
+//       "item[condition]": {
+//         required: true
+//       },
+//       "item[shipping_attributes][shipping_fee]": {
+//         required: true
+//       },
+//       "item[shipping_attributes][shippingway_id]": {
+//         required: true
+//       },
+//       "item[shipping_attributes][shippingarea_id]": {
+//         required: true
+//       },
+//       "item[shipping_attributes][shipping_day]": {
+//         required: true
+//       },
+//       "item[price]": {
+//         required: true,
+//         range: [300, 9999999]
+  
+//       }
+//     },
+//     messages: {
+//       "item[images_attributes][0][image]": {
+//         required: "画像がありません"
+//       },
+//       "item[images_attributes][1][image]": {
+//         required: "画像がありません"
+//       },
+//       "item[images_attributes][2][image]": {
+//         required: "画像がありません"
+//       },
+//       "item[images_attributes][3][image]": {
+//         required: "画像がありません"
+//       },
+//       "item[images_attributes][4][image]": {
+//         required: "画像がありません"
+//       },
+//       "item[name]": {
+//         required: "商品名を入力してください"
+//       },
+//       "item[description]": {
+//         required: "商品の説明を入力してください"
+//       },
+//       "item[parent_category_id]": {
+//         required: "カテゴリーを選択してください"
+//       },
+//       "item[child_category_id]": {
+//         required: "カテゴリーを選択してください"
+//       },
+//       "item[category_id]": {
+//         required: "カテゴリーを選択してください"
+//       },
+//       "item[condition]": {
+//         required: "商品の状態を選択してください"
+//       },
+//       "item[shipping_attributes][shipping_fee]": {
+//         required: "配送料の負担を選択してください"
+//       },
+//       "item[shipping_attributes][shippingway_id]": {
+//         required: "配送方法を選択してください"
+//       },
+//       "item[shipping_attributes][shippingarea_id]": {
+//         required: "配送元の地域を選択してください"
+//       },
+//       "item[shipping_attributes][shipping_day]": {
+//         required: "配送までの日数を選択してください"
+//       },
+//       "item[price]": {
+//         required: "販売価格を入力してください",
+//         range: "300以上9999999以下で入力してください"
+//       }
+//     },
+//     errorClass: "form-invalid",
+//     errorElement: "p", 
+//     validClass: "valid",
+//     errorPlacement: function(error, element){
+
+//       // メッセージ表示場所の変更
+//       // 【お名前】のようにフォームが2つセットのものは、デフォルトだとそれぞれのフォーム直下にメッセージが出てしまいレイアウトが崩れてしまうため、
+//       // 表示場所をその親の直下に出てくるように変更
+//       if(element.attr('name') === 'item[images_attributes][0][image]' || element.attr('name') === 'item[images_attributes][1][image]' || element.attr('name') === 'item[images_attributes][2][image]' || element.attr('name') === 'item[images_attributes][3][image]' || element.attr('name') === 'item[images_attributes][4][image]'){
+//         error.insertAfter('#label-box--0'); 
+//       }else{    //標準出力箇所（フォーム項目の後にエラーメッセージを出力）
+//           error.insertAfter(element);
+//       }
+//     }
+  
+//   })
+//   $('#new_item').on('blur', '#item_name, #item_description, #parent_category, #child_category, #grandchild_category, #item_condition, #item_shipping_attributes_shipping_fee, #item_shipping_attributes_shippingway_id, #item_shipping_attributes_shippingarea_id, #item_shipping_attributes_shipping_day, #item_price', function() {   
+//     $(this).valid();
+
+//   });
+//   $(document).on('blur','#item_images_attributes_0_image, #item_images_attributes_1_image, #item_images_attributes_2_image, #item_images_attributes_3_image, #item_images_attributes_4_image', function() {   
+//     $(this).valid();
+//   });
+// })

--- a/app/assets/javascripts/validate_item.js
+++ b/app/assets/javascripts/validate_item.js
@@ -1,43 +1,59 @@
 $(function(){
 
+  const imagesForm = "#item_images_attributes_0_image, #item_images_attributes_1_image, #item_images_attributes_2_image, #item_images_attributes_3_image, #item_images_attributes_4_image"
+
   $('#new_item').validate({
     ignore: [],
+    // 画像フォームは複数あるので、フォームの数分エラーメッセージが表示されてしまうので
+    // grouop化してbalidateされた場合単一のメッセージを表示するように設定
     groups: {
       images: "item[images_attributes][0][image] item[images_attributes][1][image] item[images_attributes][2][image] item[images_attributes][3][image] item[images_attributes][4][image]"
     },
     rules: {
+      // 画像フォールのreruiredの設定を他の４つのフォームが空だったらrewuiredをonに、一つでも値がはいっていたらoffになるように設定
+      // 各フォームに同様の設定を施しています
       "item[images_attributes][0][image]": {
         required: function(element){
-          if ($("#item_images_attributes_1_image").val()==="" && $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
-            return true;
+          if ($("#item_images_attributes_1_image").val()!="" || $("#item_images_attributes_2_image").val()!="" || $("#item_images_attributes_3_image").val()!="" || $("#item_images_attributes_4_image").val()!=""){
+            return false
+          } else {
+            return true
           }
         }
       }, 
       "item[images_attributes][1][image]": {
         required: function(element){
-          if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
-            return true;
+          if ($("#item_images_attributes_0_image").val()!="" || $("#item_images_attributes_2_image").val()!="" || $("#item_images_attributes_3_image").val()!="" || $("#item_images_attributes_4_image").val()!=""){
+            return false
+          } else {
+            return true
           }
         }
       }, 
       "item[images_attributes][2][image]": {
         required: function(element){
-          if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
-            return true;
+          if ($("#item_images_attributes_0_image").val()!="" || $("#item_images_attributes_1_image").val()!="" || $("#item_images_attributes_3_image").val()!="" || $("#item_images_attributes_4_image").val()!=""){
+            return false
+          } else {
+            return true
           }
       }
     }, 
       "item[images_attributes][3][image]": {
         required: function(element){
-          if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()===""&& $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
-            return true;
+          if ($("#item_images_attributes_0_image").val()!="" || $("#item_images_attributes_1_image").val()!="" || $("#item_images_attributes_2_image").val()!="" || $("#item_images_attributes_4_image").val()!=""){
+            return false
+          } else {
+            return true
           }
       }
       }, 
       "item[images_attributes][4][image]": {
         required: function(element){
-          if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()===""&& $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()===""){
-            return true;
+          if ($("#item_images_attributes_0_image").val()!="" || $("#item_images_attributes_1_image").val()!="" || $("#item_images_attributes_2_image").val()!="" || $("#item_images_attributes_3_image").val()!=""){
+            return false
+          } else {
+            return true
           }
         }
       }, 
@@ -134,23 +150,20 @@ $(function(){
     errorElement: "p", 
     validClass: "valid",
     errorPlacement: function(error, element){
-
-      // メッセージ表示場所の変更
-      // 【お名前】のようにフォームが2つセットのものは、デフォルトだとそれぞれのフォーム直下にメッセージが出てしまいレイアウトが崩れてしまうため、
-      // 表示場所をその親の直下に出てくるように変更
       if(element.attr('name') === 'item[images_attributes][0][image]' || element.attr('name') === 'item[images_attributes][1][image]' || element.attr('name') === 'item[images_attributes][2][image]' || element.attr('name') === 'item[images_attributes][3][image]' || element.attr('name') === 'item[images_attributes][4][image]'){
         error.insertAfter('#label-box--0'); 
-      }else{    //標準出力箇所（フォーム項目の後にエラーメッセージを出力）
+      }else{  
           error.insertAfter(element);
       }
     }
-  
   })
-  $('#new_item').on('blur', '#item_name, #item_description, #parent_category, #child_category, #grandchild_category, #item_condition, #item_shipping_attributes_shipping_fee, #item_shipping_attributes_shippingway_id, #item_shipping_attributes_shippingarea_id, #item_shipping_attributes_shipping_day, #item_price', function() {   
+  $('#new_item').on('blur', '#item_name, #item_description, #parent_category, #child_category, #grandchild_category, #item_condition, #item_shipping_attributes_shipping_fee, #item_shipping_attributes_shippingway_id, #item_shipping_attributes_shippingarea_id, #item_shipping_attributes_shipping_day, #item_price', function() { 
+    console.log(1);  
     $(this).valid();
-
   });
-  $(document).on('blur','#item_images_attributes_0_image, #item_images_attributes_1_image, #item_images_attributes_2_image, #item_images_attributes_3_image, #item_images_attributes_4_image', function() {   
+  // 画像フォームはblurイベントだと発火しないのでchangeイベントに設定
+  $('#new_item').on('change','#item_images_attributes_0_image, #item_images_attributes_1_image, #item_images_attributes_2_image, #item_images_attributes_3_image, #item_images_attributes_4_image', function() {   
     $(this).valid();
+    console.log(2); 
   });
 })

--- a/app/assets/javascripts/validate_item.js
+++ b/app/assets/javascripts/validate_item.js
@@ -34,8 +34,8 @@ $(function(){
           } else {
             return true
           }
-      }
-    }, 
+        }
+      }, 
       "item[images_attributes][3][image]": {
         required: function(element){
           if ($("#item_images_attributes_0_image").val()!="" || $("#item_images_attributes_1_image").val()!="" || $("#item_images_attributes_2_image").val()!="" || $("#item_images_attributes_4_image").val()!=""){
@@ -43,7 +43,7 @@ $(function(){
           } else {
             return true
           }
-      }
+        }
       }, 
       "item[images_attributes][4][image]": {
         required: function(element){
@@ -89,7 +89,6 @@ $(function(){
       "item[price]": {
         required: true,
         range: [300, 9999999]
-  
       }
     },
     messages: {

--- a/app/assets/javascripts/validate_item.js
+++ b/app/assets/javascripts/validate_item.js
@@ -1,156 +1,156 @@
-// $(function(){
+$(function(){
 
-//   $('#new_item').validate({
-//     ignore: [],
-//     groups: {
-//       images: "item[images_attributes][0][image] item[images_attributes][1][image] item[images_attributes][2][image] item[images_attributes][3][image] item[images_attributes][4][image]"
-//     },
-//     rules: {
-//       "item[images_attributes][0][image]": {
-//         required: function(element){
-//           if ($("#item_images_attributes_1_image").val()==="" && $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
-//             return true;
-//           }
-//         }
-//       }, 
-//       "item[images_attributes][1][image]": {
-//         required: function(element){
-//           if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
-//             return true;
-//           }
-//         }
-//       }, 
-//       "item[images_attributes][2][image]": {
-//         required: function(element){
-//           if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
-//             return true;
-//           }
-//       }
-//     }, 
-//       "item[images_attributes][3][image]": {
-//         required: function(element){
-//           if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()===""&& $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
-//             return true;
-//           }
-//       }
-//       }, 
-//       "item[images_attributes][4][image]": {
-//         required: function(element){
-//           if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()===""&& $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()===""){
-//             return true;
-//           }
-//         }
-//       }, 
-//       "item[name]": {
-//         required: true,
-//         maxlength: 40
-//       },
-//       "item[description]": {
-//         required: true,
-//         maxlength: 1000
-//       },
-//       "item[parent_category_id]": {
-//         required: true
-//       },
-//       "item[child_category_id]": { 
-//         required: true
-//       },
-//       "item[category_id]": {
-//         required: true
-//       },
-//       "item[condition]": {
-//         required: true
-//       },
-//       "item[shipping_attributes][shipping_fee]": {
-//         required: true
-//       },
-//       "item[shipping_attributes][shippingway_id]": {
-//         required: true
-//       },
-//       "item[shipping_attributes][shippingarea_id]": {
-//         required: true
-//       },
-//       "item[shipping_attributes][shipping_day]": {
-//         required: true
-//       },
-//       "item[price]": {
-//         required: true,
-//         range: [300, 9999999]
+  $('#new_item').validate({
+    ignore: [],
+    groups: {
+      images: "item[images_attributes][0][image] item[images_attributes][1][image] item[images_attributes][2][image] item[images_attributes][3][image] item[images_attributes][4][image]"
+    },
+    rules: {
+      "item[images_attributes][0][image]": {
+        required: function(element){
+          if ($("#item_images_attributes_1_image").val()==="" && $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
+            return true;
+          }
+        }
+      }, 
+      "item[images_attributes][1][image]": {
+        required: function(element){
+          if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
+            return true;
+          }
+        }
+      }, 
+      "item[images_attributes][2][image]": {
+        required: function(element){
+          if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()==="" && $("#item_images_attributes_3_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
+            return true;
+          }
+      }
+    }, 
+      "item[images_attributes][3][image]": {
+        required: function(element){
+          if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()===""&& $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_4_image").val()===""){
+            return true;
+          }
+      }
+      }, 
+      "item[images_attributes][4][image]": {
+        required: function(element){
+          if ($("#item_images_attributes_0_image").val()==="" && $("#item_images_attributes_1_image").val()===""&& $("#item_images_attributes_2_image").val()==="" && $("#item_images_attributes_3_image").val()===""){
+            return true;
+          }
+        }
+      }, 
+      "item[name]": {
+        required: true,
+        maxlength: 40
+      },
+      "item[description]": {
+        required: true,
+        maxlength: 1000
+      },
+      "item[parent_category_id]": {
+        required: true
+      },
+      "item[child_category_id]": { 
+        required: true
+      },
+      "item[category_id]": {
+        required: true
+      },
+      "item[condition]": {
+        required: true
+      },
+      "item[shipping_attributes][shipping_fee]": {
+        required: true
+      },
+      "item[shipping_attributes][shippingway_id]": {
+        required: true
+      },
+      "item[shipping_attributes][shippingarea_id]": {
+        required: true
+      },
+      "item[shipping_attributes][shipping_day]": {
+        required: true
+      },
+      "item[price]": {
+        required: true,
+        range: [300, 9999999]
   
-//       }
-//     },
-//     messages: {
-//       "item[images_attributes][0][image]": {
-//         required: "画像がありません"
-//       },
-//       "item[images_attributes][1][image]": {
-//         required: "画像がありません"
-//       },
-//       "item[images_attributes][2][image]": {
-//         required: "画像がありません"
-//       },
-//       "item[images_attributes][3][image]": {
-//         required: "画像がありません"
-//       },
-//       "item[images_attributes][4][image]": {
-//         required: "画像がありません"
-//       },
-//       "item[name]": {
-//         required: "商品名を入力してください"
-//       },
-//       "item[description]": {
-//         required: "商品の説明を入力してください"
-//       },
-//       "item[parent_category_id]": {
-//         required: "カテゴリーを選択してください"
-//       },
-//       "item[child_category_id]": {
-//         required: "カテゴリーを選択してください"
-//       },
-//       "item[category_id]": {
-//         required: "カテゴリーを選択してください"
-//       },
-//       "item[condition]": {
-//         required: "商品の状態を選択してください"
-//       },
-//       "item[shipping_attributes][shipping_fee]": {
-//         required: "配送料の負担を選択してください"
-//       },
-//       "item[shipping_attributes][shippingway_id]": {
-//         required: "配送方法を選択してください"
-//       },
-//       "item[shipping_attributes][shippingarea_id]": {
-//         required: "配送元の地域を選択してください"
-//       },
-//       "item[shipping_attributes][shipping_day]": {
-//         required: "配送までの日数を選択してください"
-//       },
-//       "item[price]": {
-//         required: "販売価格を入力してください",
-//         range: "300以上9999999以下で入力してください"
-//       }
-//     },
-//     errorClass: "form-invalid",
-//     errorElement: "p", 
-//     validClass: "valid",
-//     errorPlacement: function(error, element){
+      }
+    },
+    messages: {
+      "item[images_attributes][0][image]": {
+        required: "画像がありません"
+      },
+      "item[images_attributes][1][image]": {
+        required: "画像がありません"
+      },
+      "item[images_attributes][2][image]": {
+        required: "画像がありません"
+      },
+      "item[images_attributes][3][image]": {
+        required: "画像がありません"
+      },
+      "item[images_attributes][4][image]": {
+        required: "画像がありません"
+      },
+      "item[name]": {
+        required: "商品名を入力してください"
+      },
+      "item[description]": {
+        required: "商品の説明を入力してください"
+      },
+      "item[parent_category_id]": {
+        required: "カテゴリーを選択してください"
+      },
+      "item[child_category_id]": {
+        required: "カテゴリーを選択してください"
+      },
+      "item[category_id]": {
+        required: "カテゴリーを選択してください"
+      },
+      "item[condition]": {
+        required: "商品の状態を選択してください"
+      },
+      "item[shipping_attributes][shipping_fee]": {
+        required: "配送料の負担を選択してください"
+      },
+      "item[shipping_attributes][shippingway_id]": {
+        required: "配送方法を選択してください"
+      },
+      "item[shipping_attributes][shippingarea_id]": {
+        required: "配送元の地域を選択してください"
+      },
+      "item[shipping_attributes][shipping_day]": {
+        required: "配送までの日数を選択してください"
+      },
+      "item[price]": {
+        required: "販売価格を入力してください",
+        range: "300以上9999999以下で入力してください"
+      }
+    },
+    errorClass: "form-invalid",
+    errorElement: "p", 
+    validClass: "valid",
+    errorPlacement: function(error, element){
 
-//       // メッセージ表示場所の変更
-//       // 【お名前】のようにフォームが2つセットのものは、デフォルトだとそれぞれのフォーム直下にメッセージが出てしまいレイアウトが崩れてしまうため、
-//       // 表示場所をその親の直下に出てくるように変更
-//       if(element.attr('name') === 'item[images_attributes][0][image]' || element.attr('name') === 'item[images_attributes][1][image]' || element.attr('name') === 'item[images_attributes][2][image]' || element.attr('name') === 'item[images_attributes][3][image]' || element.attr('name') === 'item[images_attributes][4][image]'){
-//         error.insertAfter('#label-box--0'); 
-//       }else{    //標準出力箇所（フォーム項目の後にエラーメッセージを出力）
-//           error.insertAfter(element);
-//       }
-//     }
+      // メッセージ表示場所の変更
+      // 【お名前】のようにフォームが2つセットのものは、デフォルトだとそれぞれのフォーム直下にメッセージが出てしまいレイアウトが崩れてしまうため、
+      // 表示場所をその親の直下に出てくるように変更
+      if(element.attr('name') === 'item[images_attributes][0][image]' || element.attr('name') === 'item[images_attributes][1][image]' || element.attr('name') === 'item[images_attributes][2][image]' || element.attr('name') === 'item[images_attributes][3][image]' || element.attr('name') === 'item[images_attributes][4][image]'){
+        error.insertAfter('#label-box--0'); 
+      }else{    //標準出力箇所（フォーム項目の後にエラーメッセージを出力）
+          error.insertAfter(element);
+      }
+    }
   
-//   })
-//   $('#new_item').on('blur', '#item_name, #item_description, #parent_category, #child_category, #grandchild_category, #item_condition, #item_shipping_attributes_shipping_fee, #item_shipping_attributes_shippingway_id, #item_shipping_attributes_shippingarea_id, #item_shipping_attributes_shipping_day, #item_price', function() {   
-//     $(this).valid();
+  })
+  $('#new_item').on('blur', '#item_name, #item_description, #parent_category, #child_category, #grandchild_category, #item_condition, #item_shipping_attributes_shipping_fee, #item_shipping_attributes_shippingway_id, #item_shipping_attributes_shippingarea_id, #item_shipping_attributes_shipping_day, #item_price', function() {   
+    $(this).valid();
 
-//   });
-//   $(document).on('blur','#item_images_attributes_0_image, #item_images_attributes_1_image, #item_images_attributes_2_image, #item_images_attributes_3_image, #item_images_attributes_4_image', function() {   
-//     $(this).valid();
-//   });
-// })
+  });
+  $(document).on('blur','#item_images_attributes_0_image, #item_images_attributes_1_image, #item_images_attributes_2_image, #item_images_attributes_3_image, #item_images_attributes_4_image', function() {   
+    $(this).valid();
+  });
+})

--- a/app/assets/stylesheets/_exhibition.scss
+++ b/app/assets/stylesheets/_exhibition.scss
@@ -262,7 +262,13 @@ body {
                     .input-group input {
                       @include input-group-input;
                     }
+                    input.form-invalid {
+                      @include form-error;
+                    }
                   }
+
+
+
                 }
               }
             }
@@ -303,6 +309,9 @@ body {
                     font-size: 12px;
                     line-height: 1.4em;
                   }
+                  textarea.form-invalid {
+                    @include form-error;
+                  }
                 }
               }
             }
@@ -340,6 +349,9 @@ body {
                     .category-svg {
                       @include svg;
                     }
+                    select.form-invalid {
+                      @include form-error;
+                    }
                   }
                   .category-select-child {
                     margin-top: 12px;
@@ -350,6 +362,9 @@ body {
                     .childCategory-svg {
                       @include svg;
                     }
+                    select.form-invalid {
+                      @include form-error;
+                    }
                   }
                   .category-select-grandchild {
                     margin-top: 12px;
@@ -359,6 +374,9 @@ body {
                     }
                     .grandChildCategory-svg {
                       @include svg;
+                    }
+                    select.form-invalid {
+                      @include form-error;
                     }
                   }
                 }
@@ -417,6 +435,9 @@ body {
                     .condition-svg {
                       @include svg;
                     }
+                    select.form-invalid {
+                      @include form-error;
+                    }
                   }
                 }
               }
@@ -462,6 +483,9 @@ body {
                     .shippingfee-svg {
                       @include svg;
                     }
+                    select.form-invalid {
+                      @include form-error;
+                    }
                   }
                 }
               }
@@ -490,6 +514,9 @@ body {
                     }
                     .shippingway-svg {
                       @include svg;
+                    }
+                    select.form-invalid {
+                      @include form-error;
                     }
                   }
                 }
@@ -520,6 +547,9 @@ body {
                     .shippingarea-svg {
                       @include svg;
                     }
+                    select.form-invalid {
+                      @include form-error;
+                    }
                   }
                 }
               }
@@ -548,6 +578,9 @@ body {
                     }
                     .shippingday-svg {
                       @include svg;
+                    }
+                    select.form-invalid {
+                      @include form-error;
                     }
                   }
                 }
@@ -625,6 +658,9 @@ body {
                     input {
                       @include input-group-input;
                       text-align: right;
+                    }
+                    input.form-invalid {
+                      @include form-error;
                     }
                   }
                 }

--- a/app/assets/stylesheets/_exhibition.scss
+++ b/app/assets/stylesheets/_exhibition.scss
@@ -118,6 +118,9 @@ body {
         position: relative;
         .exhibition-form {
           display: block;
+          #error_explanation {
+            text-align: center;
+          }
           .image {
             .image-flame {
               margin: 0;

--- a/app/assets/stylesheets/mixin/_label.scss
+++ b/app/assets/stylesheets/mixin/_label.scss
@@ -90,6 +90,8 @@
   display: inline-block;
   position: relative;
   width: inherit;
+  // エラーメッセージが追加された際にプルダウンアイコンが微妙にずれてしまうのを防ぐため追記
+  max-height: 48px;
 }
 
 @mixin word-link {

--- a/app/assets/stylesheets/modules/user.scss
+++ b/app/assets/stylesheets/modules/user.scss
@@ -179,12 +179,12 @@ p.form-invalid {
   color: $error_msg;
 }
 .field_with_errors {
-  input {
+  width: inherit;
+  input, textarea, select {
     border-color: $error_msg !important;
   }
 }
 .errors {
-  display: inline;
   color: $error_msg;
 }
 #error_explanation{

--- a/app/assets/stylesheets/modules/user.scss
+++ b/app/assets/stylesheets/modules/user.scss
@@ -185,6 +185,7 @@ p.form-invalid {
   }
 }
 .errors {
+  display: inline;
   color: $error_msg;
 }
 #error_explanation{

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,7 +31,7 @@ class ItemsController < ApplicationController
   
   def create
     @item = Item.new(item_params)
-    if @item.save!
+    if @item.save
       selling_status = SellingStatus.new(item_id: @item.id, seller_id: params[:user_id], status: "出品中")
       seller = Seller.new(item_id: @item.id, user_id: params[:user_id])
       if selling_status.save && seller.save

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,6 @@ class ItemsController < ApplicationController
         render :new
       end
     else
-      flash.now[:alert] = '入力されていない項目があります。'
       render :new
     end
   end
@@ -55,7 +54,6 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to root_path
     else
-      flash.now[:alert] = 'エラーが発生しました。'
       render :edit
     end
   end

--- a/app/helpers/with_error_form_builder.rb
+++ b/app/helpers/with_error_form_builder.rb
@@ -33,4 +33,26 @@ class WithErrorFormBuilder < ActionView::Helpers::FormBuilder
     return super if options[:no_errors]
     super + pick_errors(attribute)
   end
+
+  def text_area(attribute, options={})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def number_field(attribute, options={})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def collection_select(attribute, collection, value_method, text_method, options = {}, html_options = {})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+ def select(attribute, choices = nil, options = {}, html_options = {}, &block)
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  
 end

--- a/app/views/items/_topContents.html.haml
+++ b/app/views/items/_topContents.html.haml
@@ -1,6 +1,4 @@
 .insideHeader
-  -# ログイン・ログアウト時のみflashメッセージ表示したいので、application.html.hamlからこちらに移動
-  = render 'layouts/notifications'
   .mainHeader
     %h1.logo
       = link_to "#" 

--- a/app/views/items/_topContents.html.haml
+++ b/app/views/items/_topContents.html.haml
@@ -1,4 +1,5 @@
 .insideHeader
+  -# ログイン・ログアウト時のみflashメッセージ表示したいので、application.html.hamlからこちらに移動
   = render 'layouts/notifications'
   .mainHeader
     %h1.logo

--- a/app/views/items/_topContents.html.haml
+++ b/app/views/items/_topContents.html.haml
@@ -1,4 +1,5 @@
 .insideHeader
+  = render 'layouts/notifications'
   .mainHeader
     %h1.logo
       = link_to "#" 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -18,7 +18,7 @@
     .container
       .exhibition
         .exhibition-form
-          = form_with model: @item, local: true do |f|
+          = form_with model: @item, id: 'new_item', builder: WithErrorFormBuilder, local: true do |f|
             = hidden_field_tag :user_id, current_user.id
             %section.image
               .image-flame

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -20,6 +20,7 @@
     .container
       .exhibition
         .exhibition-form
+          = render 'layouts/error_messages', resource: @item
           = form_with model: @item, id: 'new_item', builder: WithErrorFormBuilder, local: true do |f|
             = hidden_field_tag :user_id, current_user.id
             %section.image

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -20,7 +20,7 @@
     .container
       .exhibition
         .exhibition-form
-          = form_with model: @item, local: true do |f|
+          = form_with model: @item, id: 'new_item', builder: WithErrorFormBuilder, local: true do |f|
             = hidden_field_tag :user_id, current_user.id
             %section.image
               .image-flame

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -20,6 +20,8 @@
     .container
       .exhibition
         .exhibition-form
+        -# jsのバリデーションが何かしらの不具合で発動しない場合、
+        -# 通常のモデルバリデーションでメッセージが表示されるように設定
           = render 'layouts/error_messages', resource: @item
           = form_with model: @item, id: 'new_item', builder: WithErrorFormBuilder, local: true do |f|
             = hidden_field_tag :user_id, current_user.id

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -20,8 +20,8 @@
     .container
       .exhibition
         .exhibition-form
-        -# jsのバリデーションが何かしらの不具合で発動しない場合、
-        -# 通常のモデルバリデーションでメッセージが表示されるように設定
+          -# jsのバリデーションが何かしらの不具合で発動しない場合
+          -# 通常のモデルバリデーションでメッセージが表示されるように設定
           = render 'layouts/error_messages', resource: @item
           = form_with model: @item, id: 'new_item', builder: WithErrorFormBuilder, local: true do |f|
             = hidden_field_tag :user_id, current_user.id

--- a/app/views/layouts/_error_messages.html.haml
+++ b/app/views/layouts/_error_messages.html.haml
@@ -4,6 +4,3 @@
       = I18n.t("errors.messages.not_saved",                 |
         count: resource.errors.count,                       |
         resource: resource.class.model_name.human.downcase) |
-    %ul
-      - resource.errors.full_messages.each do |message|
-        %li= message

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,6 +25,6 @@
             = link_to "新規登録", new_user_registration_path, method: :get
     .breadcrumbs
       = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"
-
-    = render 'layouts/notifications'
+    
+  
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,5 +26,5 @@
     .breadcrumbs
       = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"
     
-  
+    = render 'layouts/notifications'
     = yield

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -36,6 +36,7 @@
       .account-page__inner--title
         %h2 会員情報入力
       .account-page__inner--box
+        -# エラーメッセージファイルを出品ページでも使うので共通化、ファイル場所変更したのでそれに合わせて変更
         = render "layouts/error_messages", resource: @user
         .account-page__inner--box--user-form
           -# 作成したフォームビルダーを設定↓

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -36,7 +36,7 @@
       .account-page__inner--title
         %h2 会員情報入力
       .account-page__inner--box
-        = render "devise/shared/error_messages", resource: @user
+        = render "layouts/error_messages", resource: @user
         .account-page__inner--box--user-form
           -# 作成したフォームビルダーを設定↓
           = form_for @user, url: user_registration_path, builder: WithErrorFormBuilder do |f| 

--- a/app/views/users/registrations/new_shipping_address.html.haml
+++ b/app/views/users/registrations/new_shipping_address.html.haml
@@ -39,7 +39,7 @@
         .account-page__inner--box--user-form
           -# 作成したフォームビルダーを設定↓
           = form_for(@shipping_address, url: shipping_addresses_path, builder: WithErrorFormBuilder ) do |f| 
-            = render "devise/shared/error_messages", resource: @shipping_address 
+            = render "layouts/error_messages", resource: @shipping_address
             .field
               .field__label
                 = f.label :first_name, "お名前(全角)"

--- a/app/views/users/registrations/new_shipping_address.html.haml
+++ b/app/views/users/registrations/new_shipping_address.html.haml
@@ -39,6 +39,7 @@
         .account-page__inner--box--user-form
           -# 作成したフォームビルダーを設定↓
           = form_for(@shipping_address, url: shipping_addresses_path, builder: WithErrorFormBuilder ) do |f| 
+          -# エラーメッセージファイルを出品ページでも使うので共通化、ファイル場所変更したのでそれに合わせて変更
             = render "layouts/error_messages", resource: @shipping_address
             .field
               .field__label

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -41,9 +41,24 @@ ja:
         city: 市区町村
         house_number: 番地
         phone_number: 電話番号
+      item:
+        category: 孫カテゴリー
+        name: 商品名
+        description: 商品の説明
+        price: 販売価格
+        condition: 商品の状態
+        parent_category_id: 親カテゴリー
+        child_category_id: 子カテゴリー
+        images: 出品画像
+      shipping:
+        shipping_day: 配送までの日数
+        shipping_fee: 配送料の負担
+        shippingarea_id: 配送元の地域
+        shippingway_id: 配送方法
     models:
       user: ユーザー
       shipping_address: 住所
+      item: 商品
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。


### PR DESCRIPTION
# What
・新規出品・編集の際のバリデーションエラーメッセージが各フォーム直下に表示されるように修正
・また、jsを使用してフォームボタンを押す前にメッセージが出るように追加(jqueryの拡張機能のjQuery Validation Pluginを使用→https://jqueryvalidation.org/)
・jsでのバリデーションにて、文字数、販売金額の制限を追加

# Why
・どこにどんなエラーが出ているのか、ユーザーに分かりやすく伝えるため。