### PR TITLE
ブランド名保存機能

### DIFF
--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -103,7 +103,11 @@
                       %span.label-group__required 任意
                   .brand-section__input
                     .input-group
-                      = f.text_field :brand_id, autocomplete: "off", placeholder: "例）シャネル"
+                      -# = f.text_field :brand_id, autocomplete: "off", placeholder: "例）シャネル"
+                      - if @item.brand_id
+                        = text_field_tag :input, @item.brand.name, placeholder: "例）シャネル"
+                      - else
+                        = text_field_tag :input, "", placeholder: "例）シャネル"
               .condition
                 .condition-section
                   .condition-section__name

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -96,7 +96,8 @@
                       %span.label-group__required 任意
                   .brand-section__input
                     .input-group
-                      = f.text_field :brand_id, autocomplete: "off", placeholder: "例）シャネル"
+                      -# = f.text_field :brand_id, autocomplete: "off", placeholder: "例）シャネル"
+                      = text_field_tag :input, "", placeholder: "例）シャネル"
               .condition
                 .condition-section
                   .condition-section__name


### PR DESCRIPTION
# what

・参考サイトメルカリと同じようにテキストフォームでブランド名を入力・保存出来るようにした。

フォームをtext_fieldからtext_field_tagへ変更(コントローラでストロングパラメーターとは別でデータを受け取りたいため)。
出品の際にブランド名を入力、brandテーブルに既にあるブランド名の場合は、そのbrandのidをitemテーブルのbrand_idに追加して保存。
brandテーブルにまだないブランド名だった場合は、brandテーブルに新規でデータを作成した後にそのbrandのidをitemテーブルのbrand_idに追加して保存。

# why

選択式のフォームだと選択肢が多いため使いづらいと考え
テキスト入力タイプで入力出来るようにした。