### PR TITLE
【マークアップ】パンくず装飾&【サーバーサイド】マイページの支払い方法ページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "reset";
 @import "config/colors";
 @import "mixin/item";
+@import "modules/breadcrumb";
 @import "modules/item";
 @import "modules/mainContents";
 @import "font-awesome-sprockets";

--- a/app/assets/stylesheets/modules/breadcrumb.scss
+++ b/app/assets/stylesheets/modules/breadcrumb.scss
@@ -1,0 +1,26 @@
+.breadcrumbs {
+  border-top: 1px solid #eee;
+  background: #f5f5f5;
+  -webkit-box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
+  box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
+  background: #fff;
+  z-index: 1;
+  
+  .breadcrumbs-list {
+    overflow: visible;
+    // width: 750px;
+    max-width: 990px;
+    width: 100%;
+
+    margin: 0 auto;
+    padding: 16px 0;
+    white-space: normal;
+    a {
+      text-decoration: none;
+      color: #333;
+    }
+    .current {
+      font-weight: 600;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/breadcrumb.scss
+++ b/app/assets/stylesheets/modules/breadcrumb.scss
@@ -4,23 +4,31 @@
   -webkit-box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
   box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
   background: #fff;
-  z-index: 1;
+  // max-width: 1040px;
   
-  .breadcrumbs-list {
-    overflow: visible;
-    // width: 750px;
-    max-width: 990px;
-    width: 100%;
-
-    margin: 0 auto;
-    padding: 16px 0;
-    white-space: normal;
-    a {
+  @media screen and (min-width: 1150px){
+    .breadcrumbs-list {
+      max-width: 1040px;
+      width: 100%;
+      margin: 0 auto;
+      padding: 16px 0;
+    }
+  }
+  @media screen and (max-width: 1150px){
+    .breadcrumbs-list {
+      width: 100%;
+      // margin: 0 auto;
+      padding: 16px 0 16px 60px;
+  }
+  }
+  .breadcrumbs-list a {
       text-decoration: none;
       color: #333;
     }
     .current {
       font-weight: 600;
     }
-  }
+  
 }
+
+

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -18,7 +18,7 @@ class CardController < ApplicationController
       @card = Payment.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       #@cardインスタンス変数にpaymentsテーブルの各カラムに入れたい情報を代入
       if @card.save
-        redirect_to action: "show"
+        redirect_to controller: :cards, action: "index"
       else
         redirect_to action: "new"
       end
@@ -34,7 +34,7 @@ class CardController < ApplicationController
       customer.delete #payjpサーバーのデータ削除
       card.delete #DBのデータ削除
     end
-      redirect_to action: "new"
+      redirect_to controller: :cards, action: "index"
   end
 
   def show #Cardのデータpayjpに送り情報を取り出します

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,6 +1,29 @@
 class CardsController < ApplicationController
 
   def index
+    card = Payment.where(user_id: current_user.id).first
+    if card.present?
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      @default_card_information = customer.cards.retrieve(card.card_id)
+      @card_brand = @default_card_information.brand
+      @card_month = @default_card_information.exp_month
+      @card_year = @default_card_information.exp_year % 1000
+      case @card_brand
+      when "Visa" then
+        @card_image = "cc-visa fa-2x"
+      when "MasterCard" then
+        @card_image = "cc-mastercard fa-2x"
+      when "JCB" then
+        @card_image = "cc-jcb fa-2x"
+      when "American Express" then
+        @card_image = "cc-amex fa-2x"
+      when "Diners Club" then
+        @card_image = "cc-diners-club fa-2x"
+      when "Discover" then
+        @card_image = "cc-discover fa-2x"
+      end
+    end
   end
 
 end

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -36,7 +36,7 @@
                       %span 有効期限
                       = "#{@card_month}" + " / " + "#{@card_year}"
                     .card-list__main__info__change
-                      = link_to '変更する', delete_card_index_path, method: :post
+                      = link_to '変更する', cards_users_path
                     .card-list__main__info__brand
                       = icon("fab", "#{@card_image}")
                 - else


### PR DESCRIPTION
# what
・パンくずリストのcssの編集
見やすいように装飾編集

・マイページの支払い方法ページの編集
カードが登録してる場合に登録済カードデータが表示される。
追加、削除した後の画面の遷移をマイページの支払い方法一覧で統一。

# why
見やすく快適なアプリにするため。